### PR TITLE
Live activity edits

### DIFF
--- a/Loop Widget Extension/Live Activity/ChartView.swift
+++ b/Loop Widget Extension/Live Activity/ChartView.swift
@@ -69,7 +69,7 @@ struct ChartView: View {
                     PointMark (x: .value("Date", item.x),
                                y: .value("Glucose level", item.y)
                     )
-                    .symbolSize(20)
+                    .symbolSize(10)
                     .foregroundStyle(by: .value("Color", item.color))
                 }
                 
@@ -77,14 +77,15 @@ struct ChartView: View {
                     LineMark (x: .value("Date", item.x),
                               y: .value("Glucose level", item.y)
                     )
-                    .lineStyle(StrokeStyle(lineWidth: 3, dash: [2, 3]))
+                    .lineStyle(StrokeStyle(lineWidth: 2, dash: [6, 5]))
+                    .foregroundStyle(by: .value("Color", item.color))
                 }
             }
             .chartForegroundStyleScale([
                 "Good": .green,
                 "High": .orange,
                 "Low": .red,
-                "Default": .blue
+                "Default": Color("glucose")
             ])
             .chartPlotStyle { plotContent in
                 plotContent.background(.cyan.opacity(0.15))

--- a/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
+++ b/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
@@ -177,23 +177,34 @@ struct GlucoseLiveActivityConfiguration: Widget {
                 .stroke(getLoopColor(context.state.lastCompleted), lineWidth: 6)
                 .rotationEffect(Angle(degrees: -126))
                 .frame(idealWidth: 36, idealHeight: 36)
-                .frame(minWidth: 18, maxWidth: 36, minHeight: 18, maxHeight: 36)
+                .frame(minWidth: 20, maxWidth: 36, minHeight:20, maxHeight: 36)
                 .padding(.trailing, 8)
                 .layoutPriority(0)  // Lowest priority - shrinks first before the text elements
+            
+            VStack(alignment: .leading, spacing: 0) {
+                // Current BG with trend arrow + eventual BG - composed as single string so they scale together
+                let glucoseFormatter = NumberFormatter.glucoseFormatter(for: context.state.isMmol ? HKUnit.millimolesPerLiter : HKUnit.milligramsPerDeciliter)
+                let currentBG = (glucoseFormatter.string(from: context.state.currentGlucose) ?? "??") + getArrowImage(context.state.trendType)
+                let eventualBG = context.state.bottomRow.first(where: { $0.label == NSLocalizedString("Event", comment: "") })?.value ?? ""
+                let combinedText = currentBG + (eventualBG.isEmpty ? "" : "  " + eventualBG)
 
-            // Current BG with trend arrow + eventual BG - composed as single string so they scale together
-            let glucoseFormatter = NumberFormatter.glucoseFormatter(for: context.state.isMmol ? HKUnit.millimolesPerLiter : HKUnit.milligramsPerDeciliter)
-            let currentBG = (glucoseFormatter.string(from: context.state.currentGlucose) ?? "??") + getArrowImage(context.state.trendType)
-            let eventualBG = context.state.bottomRow.first(where: { $0.label == NSLocalizedString("Event", comment: "") })?.value ?? ""
-            let combinedText = currentBG + (eventualBG.isEmpty ? "" : "  " + eventualBG)
-
-            Text(combinedText)
-                .font(.system(size: 40, weight: .bold))
-                .foregroundStyle(!context.attributes.useLimits ? .primary : getGlucoseColor(context.state.currentGlucose, context: context))
-                .monospacedDigit()
-                .lineLimit(1)
-                .minimumScaleFactor(0.6)
-                .layoutPriority(1)  // Higher priority - shrinks less aggressively than the Loop icon
+                Text(combinedText)
+                    .font(.system(size: 40, weight: .bold))
+                    .foregroundStyle(!context.attributes.useLimits ? .primary : getGlucoseColor(context.state.currentGlucose, context: context))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                                  
+                HStack() {
+                    Text(context.state.delta)
+                        .foregroundStyle(Color(white: 0.9))
+                        .font(.system(size: 25))
+                    Text(context.state.isMmol ? HKUnit.millimolesPerLiter.localizedShortUnitString : HKUnit.milligramsPerDeciliter.localizedShortUnitString)
+                        .foregroundStyle(Color(white: 0.7))
+                        .font(.subheadline)
+                }
+                .padding(.leading)
+            }
+            .layoutPriority(1)
         }
         .frame(maxWidth: .infinity)  // Allow HStack to use full available width
         .privacySensitive()
@@ -383,4 +394,5 @@ struct GlucoseLiveActivityConfiguration: Widget {
         
         return .green
     }
+
 }

--- a/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
+++ b/Loop Widget Extension/Live Activity/GlucoseLiveActivityConfiguration.swift
@@ -16,21 +16,67 @@ import HealthKit
 
 @available(iOS 16.2, *)
 struct GlucoseLiveActivityConfiguration: Widget {
-    private let timeFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .none
-        dateFormatter.timeStyle = .short
-        
-        return dateFormatter
-    }()
-    
     var body: some WidgetConfiguration {
-        ActivityConfiguration(for: GlucoseActivityAttributes.self) { context in
-            // Create the presentation that appears on the Lock Screen and as a
-            // banner on the Home Screen of devices that don't support the Dynamic Island.
-            ZStack {
-                VStack {
-                    if context.attributes.mode == .large {
+        if #available(iOS 18.0, *) {
+            return ActivityConfiguration(for: GlucoseActivityAttributes.self) { context in
+                lockScreenView(context: context)
+            } dynamicIsland: { context in
+                dynamicIslandView(context: context)
+            }
+            .supplementalActivityFamilies([.small])
+        } else {
+            return ActivityConfiguration(for: GlucoseActivityAttributes.self) { context in
+                lockScreenView(context: context)
+            } dynamicIsland: { context in
+                dynamicIslandView(context: context)
+            }
+        }
+    }
+
+    // MARK: - Lock Screen View
+
+    @ViewBuilder
+    private func lockScreenView(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
+        // Create the presentation that appears on the Lock Screen and as a
+        // banner on the Home Screen of devices that don't support the Dynamic Island.
+        if #available(iOS 18.0, *) {
+            AdaptiveLockScreenView(context: context)
+        } else {
+            fullLockScreenView(context: context)
+        }
+    }
+
+    @available(iOS 18.0, *)
+    struct AdaptiveLockScreenView: View {
+        let context: ActivityViewContext<GlucoseActivityAttributes>
+        @Environment(\.activityFamily) private var activityFamily
+
+        var body: some View {
+            if activityFamily == .small {
+                // CarPlay supplemental view - show only bottom row
+                compactLockScreenView(context: context)
+            } else {
+                // Lock screen - show full view with chart
+                fullLockScreenView(context: context)
+            }
+        }
+
+        @ViewBuilder
+        private func fullLockScreenView(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
+            GlucoseLiveActivityConfiguration().fullLockScreenView(context: context)
+        }
+
+        @ViewBuilder
+        private func compactLockScreenView(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
+            GlucoseLiveActivityConfiguration().compactLockScreenView(context: context)
+        }
+    }
+
+    @ViewBuilder
+    private func fullLockScreenView(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
+        ZStack {
+            VStack {
+                if context.attributes.mode == .large {
                         HStack(spacing: 15) {
                             loopIcon(context)
                             if context.attributes.addPredictiveLine {
@@ -115,10 +161,53 @@ struct GlucoseLiveActivityConfiguration: Widget {
                 .padding(.all, 15)
                 .background(BackgroundStyle.background.opacity(0.4))
                 .activityBackgroundTint(Color.clear)
-        } dynamicIsland: { context in
+    }
+
+    @ViewBuilder
+    private func compactLockScreenView(context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
+        /* Simple large display for CarPlay and Apple Watch - single row with Loop icon,
+           current BG with trend, and eventual BG. Larger fonts for CarPlay readability,
+           elements scale down on Watch to avoid truncation.
+        */
+        HStack(spacing: 0) {
+            // Loop icon - color coded, least important (only color matters)
+            // Scales down aggressively on narrow displays
+            Circle()
+                .trim(from: context.state.isCloseLoop ? 0 : 0.2, to: 1)
+                .stroke(getLoopColor(context.state.lastCompleted), lineWidth: 6)
+                .rotationEffect(Angle(degrees: -126))
+                .frame(idealWidth: 36, idealHeight: 36)
+                .frame(minWidth: 18, maxWidth: 36, minHeight: 18, maxHeight: 36)
+                .padding(.trailing, 8)
+                .layoutPriority(0)  // Lowest priority - shrinks first before the text elements
+
+            // Current BG with trend arrow + eventual BG - composed as single string so they scale together
             let glucoseFormatter = NumberFormatter.glucoseFormatter(for: context.state.isMmol ? HKUnit.millimolesPerLiter : HKUnit.milligramsPerDeciliter)
-            
-            return DynamicIsland {
+            let currentBG = (glucoseFormatter.string(from: context.state.currentGlucose) ?? "??") + getArrowImage(context.state.trendType)
+            let eventualBG = context.state.bottomRow.first(where: { $0.label == NSLocalizedString("Event", comment: "") })?.value ?? ""
+            let combinedText = currentBG + (eventualBG.isEmpty ? "" : "  " + eventualBG)
+
+            Text(combinedText)
+                .font(.system(size: 40, weight: .bold))
+                .foregroundStyle(!context.attributes.useLimits ? .primary : getGlucoseColor(context.state.currentGlucose, context: context))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+                .layoutPriority(1)  // Higher priority - shrinks less aggressively than the Loop icon
+        }
+        .frame(maxWidth: .infinity)  // Allow HStack to use full available width
+        .privacySensitive()
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(Color.clear)
+    }
+
+    // MARK: - Dynamic Island View
+
+    private func dynamicIslandView(context: ActivityViewContext<GlucoseActivityAttributes>) -> DynamicIsland {
+        let glucoseFormatter = NumberFormatter.glucoseFormatter(for: context.state.isMmol ? HKUnit.millimolesPerLiter : HKUnit.milligramsPerDeciliter)
+
+        return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     HStack(alignment: .center) {
                         loopIcon(context)
@@ -181,9 +270,8 @@ struct GlucoseLiveActivityConfiguration: Widget {
                     .foregroundStyle(getGlucoseColor(context.state.currentGlucose, context: context))
                     .minimumScaleFactor(0.1)
             }
-        }
     }
-    
+
     @ViewBuilder
     private func loopIcon(_ context: ActivityViewContext<GlucoseActivityAttributes>) -> some View {
         Circle()
@@ -197,11 +285,12 @@ struct GlucoseLiveActivityConfiguration: Widget {
     private func bottomItemGeneric(title: String, value: String, unit: String) -> some View {
         VStack(alignment: .center) {
             Text("\(value)\(unit)")
+                .font(.headline)
                 .foregroundStyle(.primary)
                 .fontWeight(.heavy)
                 .font(Font.body.leading(.tight))
             Text(title)
-                .font(.caption2)
+                .font(.subheadline)
         }
     }
     


### PR DESCRIPTION
This PR adds support for `.supplementalActivityFamilies([.small])`, allowing the Live Activity to appear in the Apple Watch Smart Stack (starting with iOS 18) and in CarPlay (starting with iOS 26).  Because iOS 17 does not support this family, the code is restructured a bit to provide a different view in that case. Note that I have not tested this on an actual iOS 17 device. 

In addition, this PR addresses the following issues: 
* Make the point size smaller on the graph to reduce crowding
* Update the color of the glucose points and prediction line on the graph to use the Loop standard `.glucose` color. 
* Change the dash style of the prediction line to match the graph in the main Loop app

Known remaining issues: 
* This does not address the issue flagged in the original PR about replacing "IOB" and "COB" with "Active insulin" and "Active carbs".  That will require a more fundamental change to the layout of the main display, possibly to add another label row and/or to reduce the number of displayed items. 
* It should be possible to tap on the Live Activity in the Watch Smart Stack and get it to launch the Watch app (described at 5:35 in (this video)[https://developer.apple.com/videos/play/wwdc2024/10068/]).  I tried adding that flag, but I was unable to get that to work. 
* There is a bug in iOS 26.0.1 that sometimes causes doubled images in the CarPlay display - the previous text is not cleared when new text is displayed, if the phone screen is off.  This appears to be fixed in iOS 26.1 beta 4. 

Let me know if you have questions! 